### PR TITLE
Add a feature to use other external JAR files

### DIFF
--- a/javafunction.html
+++ b/javafunction.html
@@ -40,6 +40,8 @@
         category: 'function',
         defaults: {
             name: { value: "" },
+			jars: { value: [] },
+			imports: { value: [] },
             func: { value: 'JsonObject jo = new JsonObject();\n'
                         + 'jo.addProperty("message", "Hello Java instead of JavaScript!");\n'
                         + 'jo.addProperty("payload", msg.get("payload").getAsString());\n'

--- a/javafunction.html
+++ b/javafunction.html
@@ -3,6 +3,14 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
+    <div class="form-row node-input-jar-container-row">
+        <label for="node-input-jar" style="width: 110px;"><i class="fa fa-file-archive-o"></i> JAR file paths</label>
+        <ol id="node-input-jar-container"></ol>
+    </div>
+    <div class="form-row node-input-import-container-row">
+        <label for="node-input-import" style="width: 130px;"><i class="fa fa-code"></i> Import statements</label>
+        <ol id="node-input-import-container"></ol>
+    </div>
     <div class="form-row" style="margin-bottom: 0px;">
         <label for="node-input-func"><i class="fa fa-wrench"></i> Function</label>
         <input type="hidden" id="node-input-func">
@@ -14,9 +22,16 @@
 
 <script type="text/x-red" data-help-name="javafunction">
     <p>A Java function node supports Java language instead of JavaScript.</p>
-    <p>The node use Gson library to handle JSON data.</p>
-    <p>See the users guide on the follwing URL.</p>
-    <p>https://github.com/google/gson/blob/master/UserGuide.md</p>
+
+	<h3>Details</h3>
+    	<p>The node uses Gson library to handle JSON data. See the users guide on the follwing URL.</p>
+		<p>To use other JAR files in a "Function" field,
+		set their paths to "JAR file paths", and set import statements to "Import statements".</p>
+
+	<h3>References</h3>
+		<ul>
+			<li><a href="https://github.com/google/gson/blob/master/UserGuide.md">Gson User Guide</a></li>
+		</ul>
 </script>
 
 <script type="text/javascript">
@@ -47,11 +62,66 @@
                 value: $("#node-input-func").val()
             });
             this.editor.focus();
-        },
+
+			$("#node-input-jar-container").css('min-height','150px').editableList({
+				addButton: true,
+				addItem: function(row, index, data) {
+					if (Object.keys(data).length == 0) {
+						data = '';
+					}
+					$('<input/>', {type: 'text', placeholder: 'Path', style: 'width: 90%', value: data}).appendTo($(row));
+				},
+				removable: true,
+				sortable: true
+			});
+
+			$("#node-input-import-container").css('min-height','150px').editableList({
+				addButton: true,
+				addItem: function(row, index, data) {
+					if (Object.keys(data).length == 0) {
+						data = '';
+					}
+					$('<input/>', {type: 'text', placeholder: 'import org.apache.commons.lang3.StringUtils;', style: 'width: 90%', value: data}).appendTo($(row));
+				},
+				removable: true,
+				sortable: true
+			});
+
+			for (let i = 0; i < this.jars.length; i++) {
+                let jar = this.jars[i];
+                $("#node-input-jar-container").editableList('addItem', jar);
+            }
+
+			for (var i = 0; i < this.imports.length; i++) {
+                let statement = this.imports[i];
+                $("#node-input-import-container").editableList('addItem', statement);
+            }
+		},
         oneditsave: function() {
             $("#node-input-func").val(this.editor.getValue());
             this.editor.destroy();
             delete this.editor;
+
+			var node = this;
+			node.jars = [];
+			var jars = $("#node-input-jar-container").editableList('items');
+			jars.each(function() {
+				let jar = $(this).find('input').val();
+				if (jar.trim().length == 0) {
+					return true;
+				}
+				node.jars.push(jar);
+			});
+
+			node.imports = [];
+			var imports = $("#node-input-import-container").editableList('items');
+			imports.each(function() {
+				let statement = $(this).find('input').val();
+				if (statement.trim().length == 0) {
+					return true;
+				}
+				node.imports.push(statement);
+			});
         },
         oneditcancel: function() {
             this.editor.destroy();


### PR DESCRIPTION
This request allows to use other external jars in the node.

If you want to use other jars, 
you set jar file's path to the newer input field "JAR file paths" and import statements to the other newer input field "Import statements".